### PR TITLE
Add beads issue tracker integration

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -1,0 +1,72 @@
+# Dolt database (managed by Dolt, not git)
+dolt/
+dolt-access.lock
+
+# Runtime files
+bd.sock
+bd.sock.startlock
+sync-state.json
+last-touched
+.exclusive-lock
+
+# Daemon runtime (lock, log, pid)
+daemon.*
+
+# Interactions log (runtime, not versioned)
+interactions.jsonl
+
+# Push state (runtime, per-machine)
+push-state.json
+
+# Lock files (various runtime locks)
+*.lock
+
+# Credential key (encryption key for federation peer auth — never commit)
+.beads-credential-key
+
+# Local version tracking (prevents upgrade notification spam after git ops)
+.local_version
+
+# Worktree redirect file (contains relative path to main repo's .beads/)
+# Must not be committed as paths would be wrong in other clones
+redirect
+
+# Sync state (local-only, per-machine)
+# These files are machine-specific and should not be shared across clones
+.sync.lock
+export-state/
+
+# Ephemeral store (SQLite - wisps/molecules, intentionally not versioned)
+ephemeral.sqlite3
+ephemeral.sqlite3-journal
+ephemeral.sqlite3-wal
+ephemeral.sqlite3-shm
+
+# Dolt server management (auto-started by bd)
+dolt-server.pid
+dolt-server.log
+dolt-server.lock
+dolt-server.port
+dolt-server.activity
+
+# Corrupt backup directories (created by bd doctor --fix recovery)
+*.corrupt.backup/
+
+# Backup data (auto-exported JSONL, local-only)
+backup/
+
+# Per-project environment file (Dolt connection config, GH#2520)
+.env
+
+# Legacy files (from pre-Dolt versions)
+*.db
+*.db?*
+*.db-journal
+*.db-wal
+*.db-shm
+db.sqlite
+bd.db
+# NOTE: Do NOT add negation patterns here.
+# They would override fork protection in .git/info/exclude.
+# Config files (metadata.json, config.yaml) are tracked by git by default
+# since no pattern above ignores them.

--- a/.beads/README.md
+++ b/.beads/README.md
@@ -1,0 +1,81 @@
+# Beads - AI-Native Issue Tracking
+
+Welcome to Beads! This repository uses **Beads** for issue tracking - a modern, AI-native tool designed to live directly in your codebase alongside your code.
+
+## What is Beads?
+
+Beads is issue tracking that lives in your repo, making it perfect for AI coding agents and developers who want their issues close to their code. No web UI required - everything works through the CLI and integrates seamlessly with git.
+
+**Learn more:** [github.com/steveyegge/beads](https://github.com/steveyegge/beads)
+
+## Quick Start
+
+### Essential Commands
+
+```bash
+# Create new issues
+bd create "Add user authentication"
+
+# View all issues
+bd list
+
+# View issue details
+bd show <issue-id>
+
+# Update issue status
+bd update <issue-id> --claim
+bd update <issue-id> --status done
+
+# Sync with Dolt remote
+bd dolt push
+```
+
+### Working with Issues
+
+Issues in Beads are:
+- **Git-native**: Stored in Dolt database with version control and branching
+- **AI-friendly**: CLI-first design works perfectly with AI coding agents
+- **Branch-aware**: Issues can follow your branch workflow
+- **Always in sync**: Auto-syncs with your commits
+
+## Why Beads?
+
+✨ **AI-Native Design**
+- Built specifically for AI-assisted development workflows
+- CLI-first interface works seamlessly with AI coding agents
+- No context switching to web UIs
+
+🚀 **Developer Focused**
+- Issues live in your repo, right next to your code
+- Works offline, syncs when you push
+- Fast, lightweight, and stays out of your way
+
+🔧 **Git Integration**
+- Automatic sync with git commits
+- Branch-aware issue tracking
+- Dolt-native three-way merge resolution
+
+## Get Started with Beads
+
+Try Beads in your own projects:
+
+```bash
+# Install Beads
+curl -sSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+
+# Initialize in your repo
+bd init
+
+# Create your first issue
+bd create "Try out Beads"
+```
+
+## Learn More
+
+- **Documentation**: [github.com/steveyegge/beads/docs](https://github.com/steveyegge/beads/tree/main/docs)
+- **Quick Start Guide**: Run `bd quickstart`
+- **Examples**: [github.com/steveyegge/beads/examples](https://github.com/steveyegge/beads/tree/main/examples)
+
+---
+
+*Beads: Issue tracking that moves at the speed of thought* ⚡

--- a/.beads/README.md
+++ b/.beads/README.md
@@ -8,6 +8,28 @@ Beads is issue tracking that lives in your repo, making it perfect for AI coding
 
 **Learn more:** [github.com/steveyegge/beads](https://github.com/steveyegge/beads)
 
+## Fresh Clone Setup
+
+The issue database is **not stored in git** (only config is committed). After cloning this repo on a new machine:
+
+1. Install `bd` and `dolt`:
+   ```powershell
+   # Windows — download binaries to ~/.local/bin
+   # bd: https://github.com/steveyegge/beads/releases
+   # dolt: https://github.com/dolthub/dolt/releases
+   # Or: npm install -g @beads/bd
+   ```
+2. Initialize a fresh local database:
+   ```bash
+   bd bootstrap
+   ```
+
+That's it — `bd list` will work and you'll start with a clean issue database local to your machine.
+
+> **Note:** Issues are not shared between machines unless you configure a Dolt remote (`bd dolt remote add origin <url>`).
+
+---
+
 ## Quick Start
 
 ### Essential Commands

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,0 +1,54 @@
+# Beads Configuration File
+# This file configures default behavior for all bd commands in this repository
+# All settings can also be set via environment variables (BD_* prefix)
+# or overridden with command-line flags
+
+# Issue prefix for this repository (used by bd init)
+# If not set, bd init will auto-detect from directory name
+# Example: issue-prefix: "myproject" creates issues like "myproject-1", "myproject-2", etc.
+# issue-prefix: ""
+
+# Use no-db mode: JSONL-only, no Dolt database
+# When true, bd will use .beads/issues.jsonl as the source of truth
+# no-db: false
+
+# Enable JSON output by default
+# json: false
+
+# Feedback title formatting for mutating commands (create/update/close/dep/edit)
+# 0 = hide titles, N > 0 = truncate to N characters
+# output:
+#   title-length: 255
+
+# Default actor for audit trails (overridden by BEADS_ACTOR or --actor)
+# actor: ""
+
+# Export events (audit trail) to .beads/events.jsonl on each flush/sync
+# When enabled, new events are appended incrementally using a high-water mark.
+# Use 'bd export --events' to trigger manually regardless of this setting.
+# events-export: false
+
+# Multi-repo configuration (experimental - bd-307)
+# Allows hydrating from multiple repositories and routing writes to the correct database
+# repos:
+#   primary: "."  # Primary repo (where this database lives)
+#   additional:   # Additional repos to hydrate from (read-only)
+#     - ~/beads-planning  # Personal planning repo
+#     - ~/work-planning   # Work planning repo
+
+# JSONL backup (periodic export for off-machine recovery)
+# Auto-enabled when a git remote exists. Override explicitly:
+# backup:
+#   enabled: false     # Disable auto-backup entirely
+#   interval: 15m      # Minimum time between auto-exports
+#   git-push: false    # Disable git push (export locally only)
+#   git-repo: ""       # Separate git repo for backups (default: project repo)
+
+# Integration settings (access with 'bd config get/set')
+# These are stored in the database, not in this file:
+# - jira.url
+# - jira.project
+# - linear.url
+# - linear.api-key
+# - github.org
+# - github.repo

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,0 +1,7 @@
+{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "server",
+  "dolt_database": "goldfish",
+  "project_id": "97defb2e-05d7-451b-aeff-814218a34caf"
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -271,7 +271,36 @@ The app is complete when:
 
 ---
 
-## � GitHub Flow
+## 🪬 Issue Tracking
+
+This project uses **bd (beads)** for local issue tracking alongside GitHub Issues.
+
+Run `bd prime` at the start of an agent session for workflow context.
+
+**Quick reference:**
+
+```
+bd ready                              # Find unblocked work to pick up
+bd create "Title" -t task -p 2       # Create a new issue (priority 0–3)
+bd create "Title" -t bug -p 1        # Create a bug
+bd update <id> --claim                # Claim a task (marks in-progress)
+bd show <id>                          # View task details
+bd close <id> --reason "Done"         # Complete an issue
+bd list                               # List all open issues
+bd dep add <child> <parent>           # Mark <child> blocked by <parent>
+```
+
+**Workflow for new features:**
+
+1. `bd create "Feature: <title>" -t task -p 2` — create a beads issue
+2. `bd update <id> --claim` — claim it before starting work
+3. Create the corresponding GitHub issue (for external visibility)
+4. Reference both IDs in commits: `Add foo (bd-abc, #42)`
+5. `bd close <id>` when done
+
+---
+
+## 🐙 GitHub Flow
 
 ### Branch Strategy
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -271,7 +271,43 @@ The app is complete when:
 
 ---
 
-## 🐟 Codename
+## � GitHub Flow
+
+### Branch Strategy
+
+| Branch | Purpose |
+|---|---|
+| `main` | Production / release |
+| `dev` | Integration — all features merge here first |
+| `feature/<issue#>-<slug>` | One branch per issue, branched from `dev` |
+
+### Workflow for New Features
+
+1. **Create a GitHub issue** describing the feature before writing any code
+2. **Branch from `dev`**: `git checkout -b feature/<issue#>-short-slug dev`
+3. Implement the feature on the branch
+4. **Open a PR targeting `dev`** with `Closes #<issue>` in the description body
+5. Merge the PR into `dev`
+6. `dev` → `main` is a separate release PR when ready to ship
+
+### Naming Conventions
+
+* Branch slug: lowercase, hyphen-separated, ≤ 4 words (e.g. `feature/42-overtime-grace-period`)
+* PR title: imperative mood, matches issue title (e.g. `Add overtime grace period`)
+* Commit messages: imperative mood, reference issue where relevant (e.g. `Add grace period config (#42)`)
+
+### Copilot Guidance
+
+When helping with a new feature:
+
+1. Confirm or create a GitHub issue for it first
+2. Ensure work is on a `feature/*` branch, not directly on `dev` or `main`
+3. PR description must include `Closes #<issue>` so the issue auto-closes on merge
+4. Target PR at `dev`, never directly at `main`
+
+---
+
+## �🐟 Codename
 
 Internal codename: **goldfish**
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,14 @@ name: CI Build
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - dev
+      - 'feature/**'
+  pull_request:
+    branches:
+      - main
+      - dev
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ _ReSharper*/
 !.vscode/tasks.json
 !.vscode/settings.json
 !.vscode/extensions.json
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,8 @@
+{
+  "servers": {
+    "beads": {
+      "command": "beads-mcp",
+      "args": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Integrates the [beads](https://github.com/steveyegge/beads) issue tracker into the goldfish project.

## Changes

- **`.beads/`** — initialized beads Dolt database (config committed; database itself is gitignored)
- **`.vscode/mcp.json`** — configures `beads-mcp` MCP server so GitHub Copilot Chat can interact with beads using natural language
- **`.github/copilot-instructions.md`** — added `## 🪬 Issue Tracking` section with `bd` quick-reference and agent workflow
- **`.beads/README.md`** — added fresh clone setup instructions explaining `bd bootstrap` for new machines

## Setup required on each machine

Install `bd` and `dolt`, then run `bd bootstrap` in the repo root. See `.beads/README.md` for details.

## Testing

- CLI: `bd list` / `bd status` ✓
- MCP round-trip: created and closed a test issue via Copilot MCP tools ✓