### PR TITLE
Add startup splash screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,14 @@
     <title>CuePilot</title>
     <link rel="stylesheet" href="/css/site.css" />
 </head>
-<body>
+<body class="start-splash-active">
+    <div id="startup-splash" class="start-splash" role="status" aria-live="polite" aria-label="CuePilot is loading">
+        <div class="start-splash-card">
+            <img id="startup-splash-logo" class="start-splash-logo" src="" alt="CuePilot logo" />
+            <h1 class="start-splash-title"><span class="app-title-accent">Cue</span>Pilot</h1>
+            <p class="start-splash-tagline">Stay in flow. Stay on time.</p>
+        </div>
+    </div>
     <main class="start-layout">
         <div class="start-header">
             <h1 class="app-title"><span class="app-title-accent">Cue</span>Pilot</h1>

--- a/src/start.ts
+++ b/src/start.ts
@@ -4,8 +4,61 @@ import { CourseSummary } from './models/course-authoring.js';
 import { Timeline } from './models/types.js';
 
 const PAGE_SIZE = 6;
+const START_SPLASH_MIN_VISIBLE_MS = 1200;
+const START_SPLASH_EXIT_MS = 380;
 let allCourses: CourseEntry[] = [];
 let currentPage = 0;
+
+function delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function createStartSplashController(startedAt: number): { dismiss: () => Promise<void> } {
+    const splash = document.getElementById('startup-splash') as HTMLElement | null;
+    const logo = document.getElementById('startup-splash-logo') as HTMLImageElement | null;
+
+    if (logo) {
+        logo.src = new URL('../src-tauri/icons/icon.png', import.meta.url).href;
+    }
+
+    let dismissed = false;
+    const dismiss = async (): Promise<void> => {
+        if (!splash || dismissed) return;
+        dismissed = true;
+
+        const elapsed = Date.now() - startedAt;
+        const remaining = Math.max(0, START_SPLASH_MIN_VISIBLE_MS - elapsed);
+        if (remaining > 0) {
+            await delay(remaining);
+        }
+
+        splash.classList.add('start-splash-exit');
+        document.body.classList.remove('start-splash-active');
+
+        await new Promise<void>((resolve) => {
+            let settled = false;
+            const finish = (): void => {
+                if (settled) return;
+                settled = true;
+                splash.removeEventListener('transitionend', onTransitionEnd);
+                splash.hidden = true;
+                splash.setAttribute('aria-hidden', 'true');
+                resolve();
+            };
+
+            const onTransitionEnd = (event: TransitionEvent): void => {
+                if (event.target === splash && event.propertyName === 'opacity') {
+                    finish();
+                }
+            };
+
+            splash.addEventListener('transitionend', onTransitionEnd);
+            setTimeout(finish, START_SPLASH_EXIT_MS + 80);
+        });
+    };
+
+    return { dismiss };
+}
 
 function totalPages(): number {
     return Math.max(1, Math.ceil(allCourses.length / PAGE_SIZE));
@@ -303,6 +356,7 @@ function showNewCourseDialog(): void {
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
+    const splashController = createStartSplashController(Date.now());
     document.getElementById('new-course-btn')?.addEventListener('click', showNewCourseDialog);
 
     // Load local courses (Tauri only — silently skipped in browser context)
@@ -319,6 +373,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     } catch (err) {
         const msg = err instanceof Error ? err.message : 'Unknown error';
         renderError(`Could not load courses: ${msg}`);
+    } finally {
+        await splashController.dismiss();
     }
 
     document.addEventListener('keydown', (e) => {

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -905,9 +905,104 @@ body.type-break   #segment-title { color: #d9d5cf; }
     .panel-right.panel-crossfade {
         animation: none !important;
     }
+
+    .start-splash,
+    .start-splash-card {
+        transition: none !important;
+        animation: none !important;
+    }
 }
 
 /* ── Start Page ── */
+
+body.start-splash-active {
+    overflow: hidden;
+}
+
+.start-splash {
+    position: fixed;
+    inset: 0;
+    z-index: 120;
+    display: grid;
+    place-items: center;
+    padding: 1.5rem;
+    background:
+        radial-gradient(1200px at 22% 8%, rgba(251, 191, 36, 0.09), transparent),
+        radial-gradient(900px at 76% 94%, rgba(255, 255, 255, 0.05), transparent),
+        rgba(11, 11, 12, 0.96);
+    opacity: 1;
+    visibility: visible;
+    transition: opacity 380ms ease, visibility 380ms step-end;
+}
+
+.start-splash::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+        linear-gradient(135deg, rgba(251, 191, 36, 0.02), transparent 35%),
+        linear-gradient(315deg, rgba(255, 255, 255, 0.03), transparent 40%);
+}
+
+.start-splash-exit {
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+}
+
+.start-splash-card {
+    position: relative;
+    z-index: 1;
+    width: min(36rem, 100%);
+    padding: clamp(1.7rem, 4vw, 2.4rem) clamp(1.2rem, 3vw, 2rem);
+    border-radius: 24px;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    background: rgba(0, 0, 0, 0.28);
+    backdrop-filter: blur(10px);
+    box-shadow: 0 24px 70px rgba(0, 0, 0, 0.5);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 0.9rem;
+    animation: splashCardEnter 520ms ease both;
+}
+
+.start-splash-logo {
+    width: clamp(4.2rem, 11vw, 6.8rem);
+    height: auto;
+    filter: drop-shadow(0 0 22px rgba(251, 191, 36, 0.18));
+    margin-bottom: 0.35rem;
+}
+
+.start-splash-title {
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: clamp(2.2rem, 8.5vw, 4.2rem);
+    font-weight: 700;
+    letter-spacing: -0.03em;
+    color: var(--text-main);
+    line-height: 1;
+}
+
+.start-splash-tagline {
+    color: var(--text-muted);
+    font-size: clamp(0.95rem, 2.2vw, 1.18rem);
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+@keyframes splashCardEnter {
+    from {
+        opacity: 0;
+        transform: translateY(10px) scale(0.985);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
 
 .start-layout {
     width: 100%;
@@ -1141,6 +1236,10 @@ body.type-break   #segment-title { color: #d9d5cf; }
 @media (max-width: 600px) {
     .course-grid {
         grid-template-columns: 1fr;
+    }
+
+    .start-splash-card {
+        border-radius: 18px;
     }
 }
 


### PR DESCRIPTION
Implements a startup splash overlay on course selection with CuePilot branding and tagline, minimum display timing, and smooth fade-out.\n\n- Adds startup overlay markup and tagline\n- Adds responsive splash styling and reduced-motion handling\n- Adds startup orchestration with minimum 1.2s visibility\n\nRelated: goldfish-567