### PR TITLE
Fix release build course write access denied

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,6 +1,6 @@
 use crate::course_model::{validate_timeline_strict, Timeline, ValidationError};
 use crate::course_store::{
-  delete_course, file_name_from_path, list_course_ids, parse_timeline, read_course_json,
+  CourseDirs, delete_course, file_name_from_path, list_course_ids, parse_timeline, read_course_json,
   serialize_timeline_pretty, write_course_json_atomic,
 };
 use serde::{Deserialize, Serialize};
@@ -47,12 +47,12 @@ pub struct ValidationResult {
 }
 
 #[tauri::command]
-pub fn list_local_courses() -> Result<Vec<CourseSummary>, String> {
-  let ids = list_course_ids()?;
+pub fn list_local_courses(dirs: tauri::State<CourseDirs>) -> Result<Vec<CourseSummary>, String> {
+  let ids = list_course_ids(&dirs)?;
   let mut summaries = Vec::with_capacity(ids.len());
 
   for id in ids {
-    let json = read_course_json(&id)?;
+    let json = read_course_json(&id, &dirs)?;
     let document = parse_timeline(&json)?;
     validate_timeline_strict(&document).map_err(|e| {
       format!(
@@ -86,8 +86,8 @@ pub fn list_local_courses() -> Result<Vec<CourseSummary>, String> {
 }
 
 #[tauri::command]
-pub fn load_local_course(request: CourseIdRequest) -> Result<Timeline, String> {
-  let json = read_course_json(&request.course_id)?;
+pub fn load_local_course(dirs: tauri::State<CourseDirs>, request: CourseIdRequest) -> Result<Timeline, String> {
+  let json = read_course_json(&request.course_id, &dirs)?;
   let document = parse_timeline(&json)?;
   validate_timeline_strict(&document)
     .map_err(|e| format!("validation failed at {} ({}): {}", e.path, e.code, e.message))?;
@@ -109,12 +109,12 @@ pub fn validate_course_document(request: ValidateCourseRequest) -> Result<Valida
 }
 
 #[tauri::command]
-pub fn save_course_document(request: SaveCourseRequest) -> Result<SaveCourseResult, String> {
+pub fn save_course_document(dirs: tauri::State<CourseDirs>, request: SaveCourseRequest) -> Result<SaveCourseResult, String> {
   validate_timeline_strict(&request.document)
     .map_err(|e| format!("validation failed at {} ({}): {}", e.path, e.code, e.message))?;
 
   let json = serialize_timeline_pretty(&request.document)?;
-  let (path, bytes_written) = write_course_json_atomic(&request.course_id, &json)?;
+  let (path, bytes_written) = write_course_json_atomic(&request.course_id, &json, &dirs)?;
 
   Ok(SaveCourseResult {
     id: request.course_id,
@@ -124,6 +124,6 @@ pub fn save_course_document(request: SaveCourseRequest) -> Result<SaveCourseResu
 }
 
 #[tauri::command]
-pub fn delete_local_course(request: CourseIdRequest) -> Result<bool, String> {
-  delete_course(&request.course_id)
+pub fn delete_local_course(dirs: tauri::State<CourseDirs>, request: CourseIdRequest) -> Result<bool, String> {
+  delete_course(&request.course_id, &dirs)
 }

--- a/src-tauri/src/course_store.rs
+++ b/src-tauri/src/course_store.rs
@@ -3,34 +3,14 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-const COURSES_DIR: &str = "courses";
-
-fn workspace_root() -> Result<PathBuf, String> {
-  std::env::current_dir().map_err(|e| format!("failed to resolve workspace root: {e}"))
-}
-
-fn legacy_courses_dir() -> Result<PathBuf, String> {
-  Ok(workspace_root()?.join(COURSES_DIR))
-}
-
-fn courses_dir() -> Result<PathBuf, String> {
-  let root = workspace_root()?;
-
-  // In `tauri dev`, cwd is typically `.../src-tauri` which is watch-scanned.
-  // Writing there causes app restarts on every autosave, so write to repo-root `courses/`.
-  if root.file_name() == Some(OsStr::new("src-tauri")) {
-    if let Some(parent) = root.parent() {
-      return Ok(parent.join(COURSES_DIR));
-    }
-  }
-
-  Ok(root.join(COURSES_DIR))
-}
-
-fn ensure_courses_dir() -> Result<PathBuf, String> {
-  let dir = courses_dir()?;
-  fs::create_dir_all(&dir).map_err(|e| format!("failed to create courses directory: {e}"))?;
-  Ok(dir)
+/// Resolved course storage paths, computed once at app startup.
+///
+/// `primary` is the writable directory for all new writes.  
+/// `legacy` is an optional read-only fallback (used in dev when CWD == `src-tauri`).
+pub struct CourseDirs {
+  pub primary: PathBuf,
+  /// Optional secondary directory to search when reading, but never written to.
+  pub legacy: Option<PathBuf>,
 }
 
 pub fn sanitize_course_id(course_id: &str) -> Result<String, String> {
@@ -65,28 +45,30 @@ pub fn sanitize_course_id(course_id: &str) -> Result<String, String> {
   Ok(normalized.to_string())
 }
 
-pub fn course_file_path(course_id: &str) -> Result<PathBuf, String> {
+pub fn course_file_path(course_id: &str, dirs: &CourseDirs) -> Result<PathBuf, String> {
   let safe_id = sanitize_course_id(course_id)?;
-  Ok(courses_dir()?.join(format!("{safe_id}.json")))
+  Ok(dirs.primary.join(format!("{safe_id}.json")))
 }
 
-pub fn list_course_ids() -> Result<Vec<String>, String> {
-  let primary_dir = ensure_courses_dir()?;
-  let legacy_dir = legacy_courses_dir()?;
+pub fn list_course_ids(dirs: &CourseDirs) -> Result<Vec<String>, String> {
+  fs::create_dir_all(&dirs.primary)
+    .map_err(|e| format!("failed to create courses directory: {e}"))?;
 
   let mut candidates: Vec<PathBuf> = Vec::new();
 
   let primary_entries =
-    fs::read_dir(&primary_dir).map_err(|e| format!("failed to list courses directory: {e}"))?;
+    fs::read_dir(&dirs.primary).map_err(|e| format!("failed to list courses directory: {e}"))?;
   for entry in primary_entries.filter_map(|entry| entry.ok()) {
     candidates.push(entry.path());
   }
 
-  if legacy_dir != primary_dir && legacy_dir.exists() {
-    let legacy_entries =
-      fs::read_dir(&legacy_dir).map_err(|e| format!("failed to list legacy courses directory: {e}"))?;
-    for entry in legacy_entries.filter_map(|entry| entry.ok()) {
-      candidates.push(entry.path());
+  if let Some(legacy_dir) = &dirs.legacy {
+    if legacy_dir != &dirs.primary && legacy_dir.exists() {
+      let legacy_entries = fs::read_dir(legacy_dir)
+        .map_err(|e| format!("failed to list legacy courses directory: {e}"))?;
+      for entry in legacy_entries.filter_map(|entry| entry.ok()) {
+        candidates.push(entry.path());
+      }
     }
   }
 
@@ -102,25 +84,29 @@ pub fn list_course_ids() -> Result<Vec<String>, String> {
   Ok(ids)
 }
 
-pub fn read_course_json(course_id: &str) -> Result<String, String> {
-  let path = course_file_path(course_id)?;
+pub fn read_course_json(course_id: &str, dirs: &CourseDirs) -> Result<String, String> {
+  let safe_id = sanitize_course_id(course_id)?;
+  let path = dirs.primary.join(format!("{safe_id}.json"));
   if path.exists() {
     return fs::read_to_string(&path)
       .map_err(|e| format!("failed to read course file '{}': {e}", path.display()));
   }
 
-  let legacy_path = legacy_courses_dir()?.join(format!("{course_id}.json"));
-  if legacy_path.exists() {
-    return fs::read_to_string(&legacy_path)
-      .map_err(|e| format!("failed to read legacy course file '{}': {e}", legacy_path.display()));
+  if let Some(legacy_dir) = &dirs.legacy {
+    let legacy_path = legacy_dir.join(format!("{safe_id}.json"));
+    if legacy_path.exists() {
+      return fs::read_to_string(&legacy_path)
+        .map_err(|e| format!("failed to read legacy course file '{}': {e}", legacy_path.display()));
+    }
   }
 
   Err(format!("course '{course_id}' was not found"))
 }
 
-pub fn write_course_json_atomic(course_id: &str, json: &str) -> Result<(PathBuf, usize), String> {
-  let _ = ensure_courses_dir()?;
-  let target = course_file_path(course_id)?;
+pub fn write_course_json_atomic(course_id: &str, json: &str, dirs: &CourseDirs) -> Result<(PathBuf, usize), String> {
+  fs::create_dir_all(&dirs.primary)
+    .map_err(|e| format!("failed to create courses directory: {e}"))?;
+  let target = course_file_path(course_id, dirs)?;
   let temp_name = format!("{}.tmp", target.file_name().unwrap_or_default().to_string_lossy());
   let tmp_path = target.with_file_name(temp_name);
 
@@ -143,9 +129,8 @@ pub fn write_course_json_atomic(course_id: &str, json: &str) -> Result<(PathBuf,
   Ok((target, json.len()))
 }
 
-pub fn delete_course(course_id: &str) -> Result<bool, String> {
-  let path = course_file_path(course_id)?;
-  let legacy_path = legacy_courses_dir()?.join(format!("{course_id}.json"));
+pub fn delete_course(course_id: &str, dirs: &CourseDirs) -> Result<bool, String> {
+  let path = course_file_path(course_id, dirs)?;
   let mut deleted = false;
 
   if path.exists() {
@@ -154,14 +139,18 @@ pub fn delete_course(course_id: &str) -> Result<bool, String> {
     deleted = true;
   }
 
-  if legacy_path != path && legacy_path.exists() {
-    fs::remove_file(&legacy_path).map_err(|e| {
-      format!(
-        "failed to delete legacy course file '{}': {e}",
-        legacy_path.display()
-      )
-    })?;
-    deleted = true;
+  if let Some(legacy_dir) = &dirs.legacy {
+    let safe_id = sanitize_course_id(course_id)?;
+    let legacy_path = legacy_dir.join(format!("{safe_id}.json"));
+    if legacy_path != path && legacy_path.exists() {
+      fs::remove_file(&legacy_path).map_err(|e| {
+        format!(
+          "failed to delete legacy course file '{}': {e}",
+          legacy_path.display()
+        )
+      })?;
+      deleted = true;
+    }
   }
 
   Ok(deleted)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,37 @@ mod commands;
 mod course_model;
 mod course_store;
 
+use std::ffi::OsStr;
+use tauri::Manager;
+use crate::course_store::CourseDirs;
+
+/// Resolve course storage paths at app startup.
+///
+/// In debug (dev) builds we keep the CWD-based heuristic so the dev workflow
+/// stays unchanged: courses live in `<repo>/courses/` and the old
+/// `src-tauri/courses/` directory is checked as a read fallback.
+///
+/// In release builds `std::env::current_dir()` is unreliable (it may point to
+/// `C:\Windows\System32` or the install directory, both of which are
+/// read-only). We use Tauri's `app_local_data_dir()` instead, which resolves
+/// to `%LOCALAPPDATA%\dev.cuepilot.goldfish\courses` — always writable.
+fn resolve_course_dirs(app: &tauri::App) -> Result<CourseDirs, Box<dyn std::error::Error>> {
+  if cfg!(debug_assertions) {
+    let cwd = std::env::current_dir()?;
+    let in_src_tauri = cwd.file_name() == Some(OsStr::new("src-tauri"));
+    let primary = if in_src_tauri {
+      cwd.parent().ok_or("src-tauri has no parent directory")?.join("courses")
+    } else {
+      cwd.join("courses")
+    };
+    let legacy = if in_src_tauri { Some(cwd.join("courses")) } else { None };
+    Ok(CourseDirs { primary, legacy })
+  } else {
+    let primary = app.path().app_local_data_dir()?.join("courses");
+    Ok(CourseDirs { primary, legacy: None })
+  }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()
@@ -13,6 +44,10 @@ pub fn run() {
             .build(),
         )?;
       }
+      let dirs = resolve_course_dirs(app)?;
+      std::fs::create_dir_all(&dirs.primary)
+        .map_err(|e| format!("failed to create courses directory: {e}"))?;
+      app.manage(dirs);
       Ok(())
     })
     .invoke_handler(tauri::generate_handler![


### PR DESCRIPTION
Closes #8

## What

In a packaged release build, writing/reading courses failed with an OS "access denied" error because `std::env::current_dir()` resolved to `C:\Windows\System32` or the install directory — both read-only.

## How

Added a `CourseDirs` struct resolved **once at startup** and stored as `tauri::State`:

- **Release builds** → `app.path().app_local_data_dir()/courses` (`%LOCALAPPDATA%\dev.cuepilot.goldfish\courses`) — always user-writable
- **Debug builds** → same CWD heuristic as before, dev workflow unchanged

All store functions now accept `&CourseDirs` instead of computing paths from CWD. Each Tauri command receives `tauri::State<CourseDirs>` via Tauri's dependency injection.

## Files changed

- `src-tauri/src/course_store.rs` — replace global path helpers with `CourseDirs` struct
- `src-tauri/src/lib.rs` — `resolve_course_dirs()` during `setup`, managed as state
- `src-tauri/src/commands.rs` — inject `State<CourseDirs>` into each command